### PR TITLE
Shorten `/nbh` ToneIndicator, Settings Tweaks

### DIFF
--- a/src/components/NxCard.css
+++ b/src/components/NxCard.css
@@ -22,6 +22,12 @@
     background-color: var(--background-feedback-critical) !important;
 }
 
+.nx-card-special {
+    background: linear-gradient(-22.5deg, var(--nx-green-background), var(--nx-purple-background)) !important;
+    background-origin: border-box !important;
+    background-color: unset !important;
+}
+
 .nx-card-title {
     font-family: var(--font-display);
     font-size: 16px;

--- a/src/components/settings/SpecialCard.css
+++ b/src/components/settings/SpecialCard.css
@@ -17,8 +17,8 @@
     margin-bottom: 16px;
     background-size: cover !important;
     background-position: center;
-    border-radius: 13px;
-    border: none;
+    border-radius: 12px;
+    background-origin: border-box !important;
 }
 
 .nx-special-card-flex {

--- a/src/components/settings/styles.css
+++ b/src/components/settings/styles.css
@@ -1,6 +1,8 @@
 :root {
     --nx-green: #0f9;
     --nx-purple: #70e;
+    --nx-green-background: #00ff9914;
+    --nx-purple-background: #7700ee14;
 }
 
 .nx-removeSwitchDivider div[class*="divider"] {

--- a/src/components/settings/tabs/plugins/index.tsx
+++ b/src/components/settings/tabs/plugins/index.tsx
@@ -21,6 +21,7 @@ import "./styles.css";
 import * as DataStore from "@api/DataStore";
 import { useSettings } from "@api/Settings";
 import { classNameFactory } from "@api/Styles";
+import { Flex } from "@components/Flex";
 import { NxCard, NxCardTitle } from "@components/NxCard";
 import { SettingsTab, wrapTab } from "@components/settings/tabs/BaseTab";
 import { ChangeList } from "@utils/ChangeList";
@@ -51,11 +52,15 @@ function ReloadRequiredCard({ required }: { required: boolean; }) {
             </NxCard>
             {required ? (
                 <NxCard className={classes("nx-card-warning", Margins.bottom16)}>
-                    <NxCardTitle>Restart required!</NxCardTitle>
-                    <span>Restart now to apply new plugins and their settings</span>
-                    <Button onClick={() => location.reload()} className={cl("restart-button")}>
-                        Restart
-                    </Button>
+                    <Flex flexDirection="row" style={{ justifyContent: "space-between" }}>
+                        <div>
+                            <NxCardTitle>Restart required!</NxCardTitle>
+                            <span>Restart now to apply new plugins and their settings</span>
+                        </div>
+                        <Button onClick={() => location.reload()} className={cl("restart-button")}>
+                            Restart
+                        </Button>
+                    </Flex>
                 </NxCard>
             ) : (<></>)}
         </>

--- a/src/components/settings/tabs/plugins/styles.css
+++ b/src/components/settings/tabs/plugins/styles.css
@@ -63,7 +63,6 @@
 }
 
 .nx-plugins-restart-button {
-    margin-top: 0.5em;
     background-color: var(--yellow-300) !important;
 }
 

--- a/src/components/settings/tabs/themes/LocalThemesTab.tsx
+++ b/src/components/settings/tabs/themes/LocalThemesTab.tsx
@@ -134,13 +134,13 @@ export function LocalThemesTab() {
                                 />
                             ) : (
                                 <QuickAction
-                                    text="Open Themes Folder"
+                                    text="Themes Folder"
                                     action={() => VencordNative.themes.openFolder()}
                                     Icon={FolderIcon}
                                 />
                             )}
                         <QuickAction
-                            text="Load missing Themes"
+                            text="Reload Themes"
                             action={refreshLocalThemes}
                             Icon={RestartIcon}
                         />

--- a/src/components/settings/tabs/vencord/index.tsx
+++ b/src/components/settings/tabs/vencord/index.tsx
@@ -139,7 +139,7 @@ function VencordSettings() {
                         />
                         <QuickAction
                             Icon={FolderIcon}
-                            text="Open Settings Folder"
+                            text="Settings Folder"
                             action={() => VencordNative.settings.openFolder()}
                         />
                     </>

--- a/src/plugins/toneIndicators/index.tsx
+++ b/src/plugins/toneIndicators/index.tsx
@@ -48,7 +48,7 @@ export const toneIndicators = [
     ti(["nm"], "not mad"),
     ti(["nmay"], "not mad at you"),
     ti(["lu"], "a little upset"),
-    ti(["nbh"], "vagueposting/venting directed at nobody here"),
+    ti(["nbh"], "nobody here"),
     ti(["sbtw"], "subtweeting"),
     ti(["nsb"], "not subtweeting"),
     ti(["sx", "x"], "sexual intent"), // brother ew


### PR DESCRIPTION
## Settings Tweaks
- Quick actions buttons have had their text shortened in order to not squish their icons
- Added a new special card style
  - <img width="300" alt="image" src="https://github.com/user-attachments/assets/dbf7b4f6-eb20-429c-b177-1127e54763b7" />
- Added border back to contributor card
- Moved restart button of restart notice to the left
  - Previously:<br> 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3efa2a8c-5318-4091-b4e7-fc10fd2e5aed" /><br>
  - Now:<br> <img width="300" alt="image" src="https://github.com/user-attachments/assets/d52f0bf7-16a9-428d-a058-eabeb8cd1418" />

## ToneIndicators
- Shortened `/nbh` tag to a more reasonable length
  - Previously: `vagueposting/venting directed at nobody here`
  - Now: `nobody here`